### PR TITLE
Fixes to main questline events and various H events (mostly during pure playthrough)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Apply Patch
 1. Click Code
 2. Click Download ZIP
-3. Place Data and Js in /www. Replace All.
+3. Place Data and Js in game folder. Replace All.
 
 # Unpacking Boxed Game
 1. Use https://f95zone.to/threads/enigma-vb-unpacker-v0-61.10201/ to decrypt the exe.

--- a/README.md
+++ b/README.md
@@ -2,10 +2,7 @@
 1. Click Code
 2. Click Download ZIP
 3. Place Data and Js in game folder. Replace All.
-
-# Unpacking Boxed Game
-1. Use https://f95zone.to/threads/enigma-vb-unpacker-v0-61.10201/ to decrypt the exe.
-
+   
 # How To Contribute
 TLDR 3 steps.
 


### PR DESCRIPTION
- fixed pronoun confusion
- changes to grammar for clarity
- removed the name "Enicia" from appearing during Wize's events
- fixed position of noun references in sentences in the form of "\\n[]" 
- fixed consistency of third person pronouns throughout events